### PR TITLE
Try more recent python versions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,6 +2,12 @@ name: Run CI-test
 
 on:
   push:
+    branches:
+    - main
+  pull_request:
+  schedule:
+    # run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.10, 3.12]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This PR slightly modifies the testing infrastructure so that:
+ Python versions tested go from older (for compatibility) to newer (and more likely to be on the users' computers). Please note that Python 3.8 is already obsolete for the newest versions of Astropy and other important packages.
+ Pull requests get tested. You can now see if new modifications to the code will break it, right from the pull request.
+ A cron job runs the tests every Monday. In this way, if some dependency is breaking your code, you will get a message, even if you haven't done modifications to the code and you haven't had the opportunity to check it